### PR TITLE
Constructor type definition

### DIFF
--- a/ajv.d.ts
+++ b/ajv.d.ts
@@ -4,7 +4,7 @@
 
 declare namespace ajv {
     interface AjvStatic {
-        (options?: AjvOptions): AjvInstance;
+        new (options?: AjvOptions): AjvInstance;
     }
 
     interface AjvInstance {


### PR DESCRIPTION
According samples of package, an `Ajv` instance should be created by using `new`
